### PR TITLE
Make use of `make`s implicit variables

### DIFF
--- a/.github/workflows/make.yaml
+++ b/.github/workflows/make.yaml
@@ -1,0 +1,40 @@
+
+name: Seqfu-Make-Build
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the "main" branch
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+  
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        gcc-version: [10, 12]
+    name: Build with make
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup nim
+        uses: jiro4989/setup-nim-action@v1
+        with:
+          nim-version: 2.0.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install dependencies
+        run: sudo apt install -y zlib1g-dev gcc-${{ matrix.gcc-version }} g++-${{ matrix.gcc-version }}
+
+        # Build and demo overwriting some variables
+      - name: Build
+        run: make CC=gcc-${{ matrix.gcc-version }} CXX=g++-${{ matrix.gcc-version }} CFLAGS="-O2 -Wall" CXXFLAGS="-std=c++11 -O2 -Wall"
+
+      - name: Test
+        run: make test
+          

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,11 @@ BIN=./bin
 SCRIPTS=./scripts
 SOURCE=./src
 DATA=./data
+CC=gcc
+CFLAGS=-O3
+CXX=g++
+CXXFLAGS=-std=c++11 -O3
+LDLIBS=-lz
 VERSION := $(shell grep version seqfu.nimble  | grep  -o "[0-9]\\+\.[0-9]\\+\.[0-9]\\+")
 NIMPARAM :=  --gc:orc -d:NimblePkgVersion=$(VERSION) -d:release --opt:speed 
 TARGETS=$(BIN)/seqfu $(BIN)/fu-msa $(BIN)/fu-primers $(BIN)/dadaist2-mergeseqs $(BIN)/fu-shred $(BIN)/fu-homocomp $(BIN)/fu-multirelabel $(BIN)/fu-index $(BIN)/fu-cov $(BIN)/fu-16Sregion  $(BIN)/fu-nanotags  $(BIN)/fu-orf  $(BIN)/fu-sw  $(BIN)/fu-virfilter  $(BIN)/fu-tabcheck $(BIN)/byteshift $(BIN)/SeqCountHelper $(BIN)/fu-secheck
@@ -15,7 +20,7 @@ all: $(TARGETS) $(PYTARGETS)
 
 sources/: src/sfu.nim s
 	mkdir -p sources
-	nim c --cc:gcc $(NIMPARAM) --nimcache:sources/ --genScript ./src/sfu.nim
+	nim c --cc:$(CC) $(NIMPARAM) --nimcache:sources/ --genScript ./src/sfu.nim
 	bash test/convert.sh sources/compile_sfu.sh
 
 src/deps.txt:
@@ -26,13 +31,13 @@ src/sfu.nim: ./src/fast*.nim ./src/*utils*.nim src/deps.txt seqfu.nimble
 	touch $@ 
 
 $(BIN)/byteshift: test/byte/shifter.c
-	gcc -O3 -o $@ $<
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $<
 
 $(BIN)/fu-secheck: test/byte/validate.c
-	gcc -O3 -o $@ $< -lz
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< $(LDLIBS)
 
 $(BIN)/SeqCountHelper: test/byte/count.cpp
-	g++ -std=c++11 -O3 -o $@ $< -lz
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $< $(LDLIBS)
 
 $(BIN)/fu-split: $(SCRIPTS)/fu-split
 	chmod +x $(SCRIPTS)/fu-split


### PR DESCRIPTION
See https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html

This makes is easier for the user to overwrite the compiler, e.g. to use Clang, and the compiler and linker flags.
Without such improvement I needed to use `sed` to add `LDFLAGS` support for the Bioconda build - https://github.com/bioconda/bioconda-recipes/pull/47230

Also added a new Github Actions workflow that shows usage of `make` and demoes overwriting of the implicit variables.
