### PR TITLE
Adding 8 lane NovaSeqX support

### DIFF
--- a/src/fastq_merge_lanes.nim
+++ b/src/fastq_merge_lanes.nim
@@ -8,13 +8,16 @@ import ./seqfu_utils
 type
   illuminaSample = tuple
     id: string
-    R1_L001, R1_L002, R1_L003, R1_L004: string
-    R2_L001, R2_L002, R2_L003, R2_L004: string
+    R1_L001, R1_L002, R1_L003, R1_L004, R1_L005, R1_L006, R1_L007, R1_L008: string
+    R2_L001, R2_L002, R2_L003, R2_L004, R2_L005, R2_L006, R2_L007, R2_L008: string
  
 
 proc fastq_merge_lanes(argv: var seq[string]): int =
     let args = docopt("""
 Usage: lanes [options] -o <outdir> <input_directory>
+
+NOTE: This tool supports up to 8 lanes of Illumina-formatted output files.
+Merged lane output files will be in an uncompressed format.
 
 Options:
   -o, --outdir DIR           Output directory
@@ -44,7 +47,7 @@ Options:
 
     let
       filesInPath = toSeq(walkDir($args["<input_directory>"], relative=true))
-      lanes = @["L001", "L002", "L003", "L004"]
+      lanes = @["L001", "L002", "L003", "L004", "L005", "L006", "L007", "L008"]
       strands = @["R1", "R2"]
 
     for file in filesInPath:
@@ -54,7 +57,7 @@ Options:
       let sid = (file.path).split("_")
       
       if sid[0] notin samples:
-        var s : illuminaSample = (id: sid[0], R1_L001: "", R1_L002: "", R1_L003: "", R1_L004: "", R2_L001: "", R2_L002: "", R2_L003: "", R2_L004: "")
+        var s : illuminaSample = (id: sid[0], R1_L001: "", R1_L002: "", R1_L003: "", R1_L004: "", R1_L005: "", R1_L006: "", R1_L007: "", R1_L008: "", R2_L001: "", R2_L002: "", R2_L003: "", R2_L004: "", R2_L005: "", R2_L006: "", R2_L007: "", R2_L008: "")
         samples[sid[0]] = s
       
       if sid[2] notin lanes or sid[3] notin strands:
@@ -70,6 +73,14 @@ Options:
           (samples[sid[0]]).R1_L003 = file.path
         elif sid[2] == "L004":
           (samples[sid[0]]).R1_L004 = file.path
+        elif sid[2] == "L005":
+          (samples[sid[0]]).R1_L005 = file.path
+        elif sid[2] == "L006":
+          (samples[sid[0]]).R1_L006 = file.path
+        elif sid[2] == "L007":
+          (samples[sid[0]]).R1_L007 = file.path
+        elif sid[2] == "L008":
+          (samples[sid[0]]).R1_L008 = file.path
       else:
         paired_end = true
         if sid[2] == "L001":
@@ -80,6 +91,14 @@ Options:
           (samples[sid[0]]).R2_L003 = file.path
         elif sid[2] == "L004":
           (samples[sid[0]]).R2_L004 = file.path
+        elif sid[2] == "L005":
+          (samples[sid[0]]).R2_L005 = file.path
+        elif sid[2] == "L006":
+          (samples[sid[0]]).R2_L006 = file.path
+        elif sid[2] == "L007":
+          (samples[sid[0]]).R2_L007 = file.path
+        elif sid[2] == "L008":
+          (samples[sid[0]]).R2_L008 = file.path
     
     for id, sample in samples.pairs:
    
@@ -97,7 +116,7 @@ Options:
       
       if args["--verbose"]:
         stderr.writeLine("# Processing: ", id)
-      for file in @[sample.R1_L001, sample.R1_L002,  sample.R1_L003,  sample.R1_L004]:
+      for file in @[sample.R1_L001, sample.R1_L002,  sample.R1_L003,  sample.R1_L004, sample.R1_L005, sample.R1_L006, sample.R1_L007, sample.R1_L008]:
         let inputFile = joinPath($args["<input_directory>"], file)
         if fileExists(inputFile):
           var 
@@ -114,7 +133,7 @@ Options:
       if not paired_end:
         continue
 
-      for file in @[sample.R2_L001, sample.R2_L002,  sample.R2_L003,  sample.R2_L004]:
+      for file in @[sample.R2_L001, sample.R2_L002,  sample.R2_L003,  sample.R2_L004, sample.R2_L005, sample.R2_L006, sample.R2_L007, sample.R2_L008]:
         let inputFile = joinPath($args["<input_directory>"], file)
         if fileExists(inputFile):
           var 


### PR DESCRIPTION
Modifying the lane merging maximum number from 4 to 8 to match the increased number of lanes introduced by the Illumina NovaSeqX. Also added a helpful note that output fastq files are uncompressed.